### PR TITLE
Run `clippy` on CI, autofix some CI errors

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,5 +18,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build
       run: cargo build --verbose
+    - name: Lint
+      run: cargo clippy
     - name: Run tests
       run: cargo test --verbose

--- a/ldraw/src/library.rs
+++ b/ldraw/src/library.rs
@@ -272,12 +272,12 @@ impl<'a, F: Fn(PartAlias, Result<(), ResolutionError>)>
             }
         }));
 
-        if pending.len() == 0 {
+        if pending.is_empty() {
             return false;
         }
 
         let futs = pending.iter().map(
-            |(alias, local)| self.loader.load_ref(&self.materials, alias.clone(), *local)
+            |(alias, local)| self.loader.load_ref(self.materials, alias.clone(), *local)
         ).collect::<Vec<_>>();
         
         let result = join_all(futs).await;
@@ -290,7 +290,7 @@ impl<'a, F: Fn(PartAlias, Result<(), ResolutionError>)>
                     match location {
                         FileLocation::Library(kind) => {
                             if local {
-                                self.clear_state(&alias, true);
+                                self.clear_state(alias, true);
                             }
                             local = false;
                             self.cache.write().unwrap().register(
@@ -357,7 +357,7 @@ pub async fn resolve_dependencies<F>(
 where
     F: Fn(PartAlias, Result<(), ResolutionError>),
 {
-    let mut resolver = DependencyResolver::new(materials, cache, on_update, &loader);
+    let mut resolver = DependencyResolver::new(materials, cache, on_update, loader);
 
     resolver.scan_dependencies(None, document, true);
     while resolver.resolve_pending_dependencies().await {}

--- a/tools/baker/src/main.rs
+++ b/tools/baker/src/main.rs
@@ -141,7 +141,7 @@ async fn bake(
         }
     };
 
-    let document = match parse_multipart_document(&colors, &mut BufReader::new(&file)).await {
+    let document = match parse_multipart_document(colors, &mut BufReader::new(&file)).await {
         Ok(v) => v,
         Err(err) => {
             println!("Could not parse document {}: {}", path.to_str().unwrap(), err);
@@ -151,7 +151,7 @@ async fn bake(
 
     let resolution_result = resolve_dependencies(
         Arc::clone(&cache),
-        &colors,
+        colors,
         loader,
         &document,
         &|alias, result| {
@@ -188,7 +188,7 @@ async fn bake(
                     writer.write_all(&serialized).await.unwrap();
                     writer.close().await.unwrap();
                 },
-                Err(err) => {
+                Err(_err) => {
                     format!("Could not create {}", outpath.to_str().unwrap());
                 }
             }

--- a/tools/baker/src/main.rs
+++ b/tools/baker/src/main.rs
@@ -68,7 +68,7 @@ async fn main() {
 
     let output_path = match matches.value_of("output_path") {
         Some(v) => {
-            let path = Path::new(v.clone());
+            let path = Path::new(v);
             if !path.is_dir().await {
                 panic!("{} is not a proper output directory", v);
             }

--- a/tools/viewer/common/src/lib.rs
+++ b/tools/viewer/common/src/lib.rs
@@ -311,7 +311,7 @@ impl<GL: HasContext> App<GL>
             cache,
             &self.materials,
             &self.loader,
-            &document,
+            document,
             on_update,
         )
         .await;
@@ -339,7 +339,7 @@ impl<GL: HasContext> App<GL>
         self.pointer = None;
         self.last_time = None;
         let (rendering_order, bounding_box) =
-            create_rendering_list(Rc::clone(&self.gl), &self.parts, &document);
+            create_rendering_list(Rc::clone(&self.gl), &self.parts, document);
         self.rendering_order = rendering_order;
         let center = bounding_box.center();
         self.orbit.camera.look_at = Point3::new(center.x, center.y, center.z);

--- a/tools/viewer/native/src/main.rs
+++ b/tools/viewer/native/src/main.rs
@@ -5,7 +5,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use async_std::path::{Path, PathBuf};
+use async_std::path::{PathBuf};
 use clap::{Arg, App as ClapApp};
 use glow::{self, Context};
 use glutin::{
@@ -164,7 +164,7 @@ async fn main() {
         url.path_segments_mut().unwrap().pop();
         (Some(url), None)
     } else {
-        (None, PathBuf::from(&path).parent().map(|e| PathBuf::from(e)))
+        (None, PathBuf::from(&path).parent().map(PathBuf::from))
     };
 
     let http_loader = HttpLoader::new(ldraw_url, document_base_url);


### PR DESCRIPTION
I applied some lint autofixes and added `cargo clippy` step in CI.