### PR TITLE
fix(ir): preserve geometry referencing Unknown/Unresolved colors during baking

### DIFF
--- a/ir/src/part.rs
+++ b/ir/src/part.rs
@@ -257,17 +257,18 @@ pub struct PartBufferBundleBuilder {
 }
 
 impl PartBufferBundleBuilder {
-    fn query_mesh<'a>(&'a mut self, group: &MeshGroupKey) -> Option<&'a mut MeshBuffer> {
+    fn query_mesh<'a>(&'a mut self, group: &MeshGroupKey) -> &'a mut MeshBuffer {
         match (&group.color_ref, group.bfc) {
-            (ColorReference::Current | ColorReference::Complement, true) => {
-                Some(&mut self.uncolored_mesh)
-            }
+            (ColorReference::Current | ColorReference::Complement, true) => &mut self.uncolored_mesh,
             (ColorReference::Current | ColorReference::Complement, false) => {
-                Some(&mut self.uncolored_without_bfc_mesh)
+                &mut self.uncolored_without_bfc_mesh
             }
-            (ColorReference::Color(_) | ColorReference::Unknown(_) | ColorReference::Unresolved(_), _) => {
-                Some(self.colored_meshes.entry(group.clone()).or_default())
-            }
+            (
+                ColorReference::Color(_)
+                | ColorReference::Unknown(_)
+                | ColorReference::Unresolved(_),
+                _,
+            ) => self.colored_meshes.entry(group.clone()).or_default(),
         }
     }
 
@@ -623,11 +624,9 @@ impl MeshBuilder {
                 }
             }
 
-            if let Some(mesh_buffer) = builder.query_mesh(group_key) {
-                mesh_buffer.add_indices(vertex_indices, normal_indices);
-            } else {
-                println!("Skipping unknown color group_key {:?}", group_key);
-            }
+            builder
+                .query_mesh(group_key)
+                .add_indices(vertex_indices, normal_indices);
         }
 
         if let Some(bounding_box_min) = bounding_box_min

--- a/ir/src/part.rs
+++ b/ir/src/part.rs
@@ -265,10 +265,9 @@ impl PartBufferBundleBuilder {
             (ColorReference::Current | ColorReference::Complement, false) => {
                 Some(&mut self.uncolored_without_bfc_mesh)
             }
-            (ColorReference::Color(_), _) => {
+            (ColorReference::Color(_) | ColorReference::Unknown(_) | ColorReference::Unresolved(_), _) => {
                 Some(self.colored_meshes.entry(group.clone()).or_default())
             }
-            _ => None,
         }
     }
 


### PR DESCRIPTION
## Summary

`PartBufferBundleBuilder::query_mesh` in `ir/src/part.rs` previously matched only `ColorReference::Current`, `ColorReference::Complement`, and `ColorReference::Color`, returning `None` for the `Unknown` and `Unresolved` variants. As a result, any geometry that referenced a color whose definition wasn't (yet) in the catalog was silently dropped during `bake_part_from_*`, even when a `ColorCatalog` was provided.

This patch folds `Unknown` and `Unresolved` into the same arm as `Color`, so their geometry is preserved in a dedicated mesh buffer and can be reified later via `Part::resolve_colors`.

## Repro (before the fix)

Baking a part that contains a reference to a color not in the supplied `ColorCatalog` produces a `Part` with missing geometry — no warning, no error.

## Change

```diff
-            (ColorReference::Color(_), _) => {
+            (ColorReference::Color(_) | ColorReference::Unknown(_) | ColorReference::Unresolved(_), _) => {
                 Some(self.colored_meshes.entry(group.clone()).or_default())
             }
-            _ => None,
         }
```

The wildcard arm is no longer reachable, so it's removed (compiles cleanly because `ColorReference` only has these four constructors).

## Test plan

- [x] `cargo check --workspace` passes
- [ ] Manual: bake a model that references an out-of-catalog color and confirm its geometry is present