### PR TITLE
chore: enable tokio macros and rt features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ cgmath = { version = "~0.18.0", features = ["serde"] }
 futures = "~0.3.30"
 image = "~0.24.7"
 serde = { version = "1.0.80", features = ["derive"] }
-tokio = { version = "1.37", features = ["io-util"] }
+tokio = { version = "1.37", features = ["io-util", "macros", "rt"] }
 tokio-stream = { version = "0.1", features = ["io-util"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 wgpu = { version = "29.0" }


### PR DESCRIPTION
## Summary

The workspace-level `tokio` dependency currently enables only the `io-util` feature. This is sufficient for the library code paths, but consumers that want to write `#[tokio::test]`-style tests against these crates have to add their own `tokio` dependency with `macros` and `rt` features to make the attribute macros and runtime available.

Adding `macros` and `rt` to the workspace `tokio` features is a no-op for production code paths (those features are gated on use) but unblocks `#[tokio::test]` in downstream consumers and in any in-tree tests.

## Change

```diff
-tokio = { version = "1.37", features = ["io-util"] }
+tokio = { version = "1.37", features = ["io-util", "macros", "rt"] }
```

## Test plan

- [x] `cargo check --workspace` passes