### PR TITLE
chore: ignore .DS_Store and .vscode/ in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,10 @@ Cargo.lock
 
 **/node_modules/
 **/dist/
+
+# MacOS
+.DS_Store
+
+# Visual Studio Code
+.vscode/
+


### PR DESCRIPTION
## Summary

Adds two common editor/OS artifacts to `.gitignore` so they don't show up in `git status` for contributors on macOS or using VS Code:

- `.DS_Store` — macOS Finder metadata
- `.vscode/` — VS Code workspace settings (per-user; not project config)

Both are conventional `.gitignore` entries and don't change any tracked files.

## Test plan

- [x] `.gitignore` parses cleanly