### PR TITLE
feat(library): make LibraryLoader/DocumentLoader Send on native targets

### DIFF
--- a/ldraw/src/library.rs
+++ b/ldraw/src/library.rs
@@ -27,7 +27,8 @@ pub enum FileLocation {
     Local,
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 pub trait DocumentLoader<T> {
     async fn load_document(
         &self,
@@ -36,7 +37,8 @@ pub trait DocumentLoader<T> {
     ) -> Result<MultipartDocument, ResolutionError>;
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 pub trait LibraryLoader {
     async fn load_colors(&self) -> Result<ColorCatalog, ResolutionError>;
 

--- a/ldraw/src/resolvers/http.rs
+++ b/ldraw/src/resolvers/http.rs
@@ -29,7 +29,21 @@ impl HttpLoader {
     }
 }
 
-#[async_trait(?Send)]
+/// Compile-time check that `HttpLoader::load_ref` and `load_colors` return
+/// `Send` futures on non-wasm targets. See the parallel helper in
+/// `resolvers::local` for context.
+#[cfg(not(target_arch = "wasm32"))]
+#[allow(dead_code)]
+fn _assert_httploader_futures_are_send(loader: &HttpLoader, colors: &ColorCatalog) {
+    fn assert_send<F: Send>(_: &F) {}
+    let f1 = loader.load_ref(PartAlias::from("dummy".to_string()), false, colors);
+    assert_send(&f1);
+    let f2 = loader.load_colors();
+    assert_send(&f2);
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl DocumentLoader<String> for HttpLoader {
     async fn load_document(
         &self,
@@ -46,7 +60,8 @@ impl DocumentLoader<String> for HttpLoader {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl LibraryLoader for HttpLoader {
     async fn load_colors(&self) -> Result<ColorCatalog, ResolutionError> {
         let ldraw_url_base = self.ldraw_url_base.as_ref();

--- a/ldraw/src/resolvers/local.rs
+++ b/ldraw/src/resolvers/local.rs
@@ -26,7 +26,25 @@ impl LocalLoader {
     }
 }
 
-#[async_trait(?Send)]
+/// Compile-time check: on non-wasm targets, `LocalLoader::load_ref` and
+/// `load_colors` must return `Send` futures so multi-threaded runtimes can
+/// `.await` them on a worker thread. If the future is `!Send`, this function
+/// fails to compile, which is the entire point.
+///
+/// The function is never called; its body exists only to be type-checked by
+/// the compiler.
+#[cfg(not(target_arch = "wasm32"))]
+#[allow(dead_code)]
+fn _assert_localloader_futures_are_send(loader: &LocalLoader, colors: &ColorCatalog) {
+    fn assert_send<F: Send>(_: &F) {}
+    let f1 = loader.load_ref(PartAlias::from("dummy".to_string()), false, colors);
+    assert_send(&f1);
+    let f2 = loader.load_colors();
+    assert_send(&f2);
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl DocumentLoader<PathBuf> for LocalLoader {
     async fn load_document(
         &self,
@@ -44,7 +62,8 @@ impl DocumentLoader<PathBuf> for LocalLoader {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl LibraryLoader for LocalLoader {
     async fn load_colors(&self) -> Result<ColorCatalog, ResolutionError> {
         let ldrawdir = match self.ldrawdir.clone() {


### PR DESCRIPTION
## Summary

`LibraryLoader` and `DocumentLoader` (in `ldraw/src/library.rs`) are declared with `#[async_trait(?Send)]`. That `?Send` propagates through both native resolvers (`LocalLoader`, `HttpLoader`) and through `resolve_dependencies_multipart`.

On wasm32 this is necessary — wasm-bindgen futures are deliberately `!Send` because the web platform is single-threaded. But on native, the underlying work is already `Send`:

- `LocalLoader` uses `tokio::fs::File` / `BufReader` / `try_exists` — all `Send`.
- `HttpLoader` uses `reqwest::Client` futures — also `Send`.
- The shared `PartCache` lives in `Arc<RwLock<...>>` (already `Send + Sync`).

The `?Send` was the only thing forcing native consumers running on a multi-threaded tokio runtime (e.g. Tauri's default) into ceremonies like:

```rust
tokio::task::spawn_blocking(move || {
    let rt = tokio::runtime::Builder::new_current_thread().enable_all().build()?;
    rt.block_on(async move { loader.load(&part_id).await })
}).await
```

A fresh runtime is constructed on every call. That's fine for one-shot loads but adds up for thumbnail-heavy UIs that batch dozens of part loads.

## Change

Switch the four `#[async_trait(?Send)]` attributes (the two traits in `library.rs` and the four impls across `resolvers/local.rs` and `resolvers/http.rs`) to the standard cfg-gated pattern:

```rust
#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
```

On native, futures returned by `LibraryLoader::load_ref`, `LibraryLoader::load_colors`, and `DocumentLoader::load_document` are now `Send`. On wasm32, the existing `?Send` behavior is preserved.

## Compile-time `Send` regression guard

Adds dead helper functions in each resolver whose bodies call `assert_send::<F>(_)` on the futures returned by `load_ref` and `load_colors`. These never run, but the compiler type-checks their bodies, so any future regression that makes the futures `!Send` on native will fail compilation.

## Test plan

- [x] `cargo check --workspace` passes on native
- [x] `cargo check -p ldraw --target wasm32-unknown-unknown` passes
- [x] `cargo test -p ldraw --lib` passes